### PR TITLE
Update plugins-kubernetes.md: Specify alpine so docker does not defau…

### DIFF
--- a/app/_src/gateway/plugin-development/pluginserver/plugins-kubernetes.md
+++ b/app/_src/gateway/plugin-development/pluginserver/plugins-kubernetes.md
@@ -14,7 +14,7 @@ the {{ site.base_gateway }} image, you must temporarily set the user to `root`.
 This is an example Dockerfile that explains how to mount your plugin in the {{ site.base_gateway }} image:
 
 ```dockerfile
-FROM kong
+FROM kong:alpine
 USER root
 # Example for GO:
 COPY your-go-plugin /usr/local/bin/your-go-plugin


### PR DESCRIPTION
…lt to ubuntu


### Description

What did you change and why?

I tried the Dockerfile as is and got an error:

➜  docker git:(ECOM-7714) ✗ docker compose up
[+] Building 0.0s (0/0)
Sending build context to Docker daemon  3.157kB
[+] Building 0.0s (0/0)
[+] Building 0.0s (0/0)
9d19ee268e0d: Pull complete
c95d715c4513: Pull complete
4301c643ae4f: Pull complete
4df5348ff8cc: Pull complete
Digest: sha256:88aad0fa3c603af1b2ced86f33f0c28f664bf7b53c92aec1256746136b8832ca
Status: Downloaded newer image for kong:latest
 ---> 43e05bc78243
[+] Building 0.0s (0/0)
 ---> Running in 6e963a1753ce
Removing intermediate container 6e963a1753ce
 ---> fe3b0db0390c
Step 3/10 : RUN apk update &&     apk add python3 py3-pip python3-dev musl-dev libffi-dev gcc g++ file make &&     PYTHONWARNINGS=ignore pip3 install kong-pdk
[+] Building 0.0s (0/0)
[+] Building 0.0s (0/0)
The command '/bin/sh -c apk update &&     apk add python3 py3-pip python3-dev musl-dev libffi-dev gcc g++ file make &&     PYTHONWARNINGS=ignore pip3 install kong-pdk' returned a non-zero code: 127

I realized it had downloaded the ubuntu version, but the commands relied on it being the alpine version. So I specified alpine.
